### PR TITLE
Restructure CreateUpdateItemForm

### DIFF
--- a/src/components/Vault/types/Card/VaultCardAdd.svelte
+++ b/src/components/Vault/types/Card/VaultCardAdd.svelte
@@ -66,12 +66,11 @@
 <div class="uk-modal-body">
     <ItemForm
         id="cardForm"
-        title="Card details"
         onsubmit={onSubmit}
         {itemDetails}
         {errors}
     >
-        <CardForm data={itemData} />
+        <CardForm title="Card details" data={itemData} />
     </ItemForm>
 </div>
 

--- a/src/components/Vault/types/Card/VaultCardEdit.svelte
+++ b/src/components/Vault/types/Card/VaultCardEdit.svelte
@@ -49,12 +49,11 @@
     <div class="uk-padding">
         <ItemForm
             id={formId}
-            title="Card details"
             itemDetails={vaultItemDetail}
             onsubmit={onSave} 
             {errors}
         >
-            <CardForm data={vaultItemDetail.data} />
+            <CardForm title="Card details" data={vaultItemDetail.data} />
         </ItemForm>
     </div>
 {/if}

--- a/src/components/Vault/types/Card/_CardForm.svelte
+++ b/src/components/Vault/types/Card/_CardForm.svelte
@@ -1,104 +1,108 @@
 <script lang="ts">
     import Icon from "@iconify/svelte";
 
-    let { data } = $props();
+    let { title, data } = $props();
 
     let toggleCardNumber = $state(false);
     let toggleSecurityCode = $state(false);
 
 </script>
 
-<div class="uk-margin-small uk-width-1-1">
-    <input
-        type="text"
-        aria-label="cardholder-name"
-        class="uk-input uk-border-rounded"
-        placeholder="Cardholder name"
-        bind:value={data.cardholderName}
-    >
-</div>
-<div class="uk-margin-small uk-width-1-1">
-    <div class="uk-inline uk-width-1-1">
-        <a
-            class="uk-form-icon uk-form-icon-flip"
-            aria-label="card-number-toggle"
-            href={null}
-            onclick={() => toggleCardNumber = !toggleCardNumber}
-        >
-            <Icon icon="hugeicons:{toggleCardNumber ? 'view-off-slash' : 'view'}" width="24" height="24" />
-        </a>
+{ /* @ts-ignore */ null }
+<fieldset class="uk-fieldset uk-margin" uk-grid>
+    <legend class="uk-legend uk-text-default uk-text-bold">{ title }</legend>
+    <div class="uk-margin-small uk-width-1-1">
         <input
-            type={toggleCardNumber ? "text" : "password"}
-            aria-label="card-number"
+            type="text"
+            aria-label="cardholder-name"
             class="uk-input uk-border-rounded"
-            placeholder="Card number"
-            bind:value={data.number}
+            placeholder="Cardholder name"
+            bind:value={data.cardholderName}
         >
     </div>
-</div>
-<div class="uk-margin-small uk-width-1-1">
-    <select
-        class="uk-select uk-border-rounded"
-        bind:value={data.brand}
-    >
-        <option value="">-- Select brand --</option>
-        <option value="Visa">Visa</option>
-        <option value="Mastercard">Mastercard</option>
-        <option value="American Express">American Express</option>
-        <option value="Discover">Discover</option>
-        <option value="Diners Club">Diners Club</option>
-        <option value="JBC">JBC</option>
-        <option value="Maestro">Maestro</option>
-        <option value="UnionPay">UnionPay</option>
-        <option value="RuPay">RuPay</option>
-        <option value="Other">Other</option>
-    </select>
-</div>
-<div class="uk-margin-small uk-width-1-2">
-    <select
-        class="uk-select uk-border-rounded"
-        bind:value={data.expMonth}
-    >
-        <option value="">-- Select month --</option>
-        <option value="01">01 - January</option>
-        <option value="02">02 - February</option>
-        <option value="03">03 - March</option>
-        <option value="04">04 - April</option>
-        <option value="05">05 - May</option>
-        <option value="06">06 - June</option>
-        <option value="07">07 - July</option>
-        <option value="08">08 - August</option>
-        <option value="09">09 - September</option>
-        <option value="10">10 - October</option>
-        <option value="11">11 - November</option>
-        <option value="12">12 - December</option>
-    </select>
-</div>
-<div class="uk-margin-small uk-width-1-2">
-    <input
-        type="number"
-        aria-label="card-exp-year"
-        class="uk-input uk-border-rounded"
-        placeholder="Expiration year"
-        bind:value={data.expYear}
-    >
-</div>
-<div class="uk-margin-small uk-width-1-1">
-    <div class="uk-inline uk-width-1-1">
-        <a
-            class="uk-form-icon uk-form-icon-flip"
-            aria-label="card-number-toggle"
-            href={null}
-            onclick={() => toggleSecurityCode = !toggleSecurityCode}
+    <div class="uk-margin-small uk-width-1-1">
+        <div class="uk-inline uk-width-1-1">
+            <a
+                class="uk-form-icon uk-form-icon-flip"
+                aria-label="card-number-toggle"
+                href={null}
+                onclick={() => toggleCardNumber = !toggleCardNumber}
+            >
+                <Icon icon="hugeicons:{toggleCardNumber ? 'view-off-slash' : 'view'}" width="24" height="24" />
+            </a>
+            <input
+                type={toggleCardNumber ? "text" : "password"}
+                aria-label="card-number"
+                class="uk-input uk-border-rounded"
+                placeholder="Card number"
+                bind:value={data.number}
+            >
+        </div>
+    </div>
+    <div class="uk-margin-small uk-width-1-1">
+        <select
+            class="uk-select uk-border-rounded"
+            bind:value={data.brand}
         >
-            <Icon icon="hugeicons:{toggleSecurityCode ? 'view-off-slash' : 'view'}" width="24" height="24" />
-        </a>
+            <option value="">-- Select brand --</option>
+            <option value="Visa">Visa</option>
+            <option value="Mastercard">Mastercard</option>
+            <option value="American Express">American Express</option>
+            <option value="Discover">Discover</option>
+            <option value="Diners Club">Diners Club</option>
+            <option value="JBC">JBC</option>
+            <option value="Maestro">Maestro</option>
+            <option value="UnionPay">UnionPay</option>
+            <option value="RuPay">RuPay</option>
+            <option value="Other">Other</option>
+        </select>
+    </div>
+    <div class="uk-margin-small uk-width-1-2">
+        <select
+            class="uk-select uk-border-rounded"
+            bind:value={data.expMonth}
+        >
+            <option value="">-- Select month --</option>
+            <option value="01">01 - January</option>
+            <option value="02">02 - February</option>
+            <option value="03">03 - March</option>
+            <option value="04">04 - April</option>
+            <option value="05">05 - May</option>
+            <option value="06">06 - June</option>
+            <option value="07">07 - July</option>
+            <option value="08">08 - August</option>
+            <option value="09">09 - September</option>
+            <option value="10">10 - October</option>
+            <option value="11">11 - November</option>
+            <option value="12">12 - December</option>
+        </select>
+    </div>
+    <div class="uk-margin-small uk-width-1-2">
         <input
-            type={toggleSecurityCode ? "text" : "password"}
-            aria-label="card-csv"
+            type="number"
+            aria-label="card-exp-year"
             class="uk-input uk-border-rounded"
-            placeholder="Security code"
-            bind:value={data.securityCode}
+            placeholder="Expiration year"
+            bind:value={data.expYear}
         >
     </div>
-</div>
+    <div class="uk-margin-small uk-width-1-1">
+        <div class="uk-inline uk-width-1-1">
+            <a
+                class="uk-form-icon uk-form-icon-flip"
+                aria-label="card-number-toggle"
+                href={null}
+                onclick={() => toggleSecurityCode = !toggleSecurityCode}
+            >
+                <Icon icon="hugeicons:{toggleSecurityCode ? 'view-off-slash' : 'view'}" width="24" height="24" />
+            </a>
+            <input
+                type={toggleSecurityCode ? "text" : "password"}
+                aria-label="card-csv"
+                class="uk-input uk-border-rounded"
+                placeholder="Security code"
+                bind:value={data.securityCode}
+            >
+        </div>
+    </div>
+</fieldset>

--- a/src/components/Vault/types/Login/VaultLoginAdd.svelte
+++ b/src/components/Vault/types/Login/VaultLoginAdd.svelte
@@ -63,12 +63,11 @@
 <div class="uk-modal-body">
     <ItemForm
         id="cardForm"
-        title="Login Credentials"
         onsubmit={onSubmit}
         {itemDetails}
         {errors}
     >
-        <LoginForm data={itemData} />
+        <LoginForm title="Login Credentials" data={itemData} />
     </ItemForm>
 </div>
 

--- a/src/components/Vault/types/Login/VaultLoginEdit.svelte
+++ b/src/components/Vault/types/Login/VaultLoginEdit.svelte
@@ -49,12 +49,11 @@
     <div class="uk-padding">
         <ItemForm
             id={formId}
-            title="Login Credentials"
             itemDetails={vaultItemDetail}
             onsubmit={onSave} 
             {errors}
         >
-            <LoginForm data={vaultItemDetail.data} />
+            <LoginForm title="Login Credentials" data={vaultItemDetail.data} />
         </ItemForm>
     </div>
 {/if}

--- a/src/components/Vault/types/Login/_LoginForm.svelte
+++ b/src/components/Vault/types/Login/_LoginForm.svelte
@@ -1,60 +1,66 @@
 <script lang="ts">
     import Icon from "@iconify/svelte";
 
-    let { data } = $props();
+    let { title, data } = $props();
 
     let togglePassword = $state(false);
     let toggleAuthKey = $state(false);
 
 </script>
 
-<div class="uk-margin-small uk-width-1-1">
-    <input
-        type="text"
-        aria-label="Username"
-        class="uk-input uk-border-rounded"
-        placeholder="Username"
-        bind:value={data.username}
-    >
-</div>
+{ /* @ts-ignore */ null }
+<fieldset class="uk-fieldset uk-margin" uk-grid>
+    <legend class="uk-legend uk-text-default uk-text-bold">{ title }</legend>
 
-<div class="uk-margin-small uk-width-1-1">
-    <div class="uk-inline uk-width-1-1">
-        <a
-            class="uk-form-icon uk-form-icon-flip"
-            aria-label="password-toggle"
-            href={null}
-            onclick={() => togglePassword = !togglePassword}
-        >
-            <Icon icon="hugeicons:{togglePassword ? 'view-off-slash' : 'view'}" width="24" height="24" />
-        </a>
+    <div class="uk-margin-small uk-width-1-1">
         <input
-            type={togglePassword ? "text" : "password"}
-            aria-label="password"
+            type="text"
+            aria-label="Username"
             class="uk-input uk-border-rounded"
-            placeholder="Password"
-            bind:value={data.password}
+            placeholder="Username"
+            bind:value={data.username}
         >
     </div>
-</div>
 
-<div class="uk-margin-small uk-width-1-1">
-    <div class="uk-inline uk-width-1-1">
-        <a
-            class="uk-form-icon uk-form-icon-flip"
-            aria-label="authenticator-key-toggle"
-            href={null}
-            onclick={() => toggleAuthKey = !toggleAuthKey}
-        >
-            <Icon icon="hugeicons:{toggleAuthKey ? 'view-off-slash' : 'view'}" width="24" height="24" />
-        </a>
-        <input
-            type={toggleAuthKey ? "text" : "password"}
-            aria-label="authenticator-key"
-            class="uk-input uk-border-rounded"
-            placeholder="Authenticator key"
-            bind:value={data.authenticatorKey}
-        >
+    <div class="uk-margin-small uk-width-1-1">
+        <div class="uk-inline uk-width-1-1">
+            <a
+                class="uk-form-icon uk-form-icon-flip"
+                aria-label="password-toggle"
+                href={null}
+                onclick={() => togglePassword = !togglePassword}
+            >
+                <Icon icon="hugeicons:{togglePassword ? 'view-off-slash' : 'view'}" width="24" height="24" />
+            </a>
+            <input
+                type={togglePassword ? "text" : "password"}
+                aria-label="password"
+                class="uk-input uk-border-rounded"
+                placeholder="Password"
+                bind:value={data.password}
+            >
+        </div>
     </div>
-    <span class="uk-text-meta uk-text-light">Fill 2-steps verification codes.</span>
-</div>
+
+    <div class="uk-margin-small uk-width-1-1">
+        <div class="uk-inline uk-width-1-1">
+            <a
+                class="uk-form-icon uk-form-icon-flip"
+                aria-label="authenticator-key-toggle"
+                href={null}
+                onclick={() => toggleAuthKey = !toggleAuthKey}
+            >
+                <Icon icon="hugeicons:{toggleAuthKey ? 'view-off-slash' : 'view'}" width="24" height="24" />
+            </a>
+            <input
+                type={toggleAuthKey ? "text" : "password"}
+                aria-label="authenticator-key"
+                class="uk-input uk-border-rounded"
+                placeholder="Authenticator key"
+                bind:value={data.authenticatorKey}
+            >
+        </div>
+        <span class="uk-text-meta uk-text-light">Fill 2-steps verification codes.</span>
+    </div>
+
+</fieldset>

--- a/src/components/Vault/types/SecureNote/VaultSecureNoteAdd.svelte
+++ b/src/components/Vault/types/SecureNote/VaultSecureNoteAdd.svelte
@@ -55,7 +55,6 @@
 <div class="uk-modal-body">
     <ItemForm
         id="cardForm"
-        title="Secure notes"
         onsubmit={onSubmit}
         {itemDetails}
         {errors}

--- a/src/components/Vault/types/SecureNote/VaultSecureNoteEdit.svelte
+++ b/src/components/Vault/types/SecureNote/VaultSecureNoteEdit.svelte
@@ -47,7 +47,6 @@
     <div class="uk-padding">
         <ItemForm
             id={formId}
-            title="Secure notes"
             itemDetails={vaultItemDetail}
             onsubmit={onSave} 
             {errors}

--- a/src/components/Vault/types/templates/CreateUpdateItemForm.svelte
+++ b/src/components/Vault/types/templates/CreateUpdateItemForm.svelte
@@ -7,14 +7,12 @@
 
     let {
         id,
-        title,
         itemDetails,
         onsubmit,
         errors,
         children = null
     }: {
         id: string,
-        title: string,
         itemDetails: FormItemDetails,
         onsubmit: FormCallBack,
         errors: Array<string>,
@@ -69,11 +67,7 @@
 
     <!-- Custom fieldset -->
      {#if children}
-        { /* @ts-ignore */ null }
-        <fieldset class="uk-fieldset uk-margin" uk-grid>
-            <legend class="uk-legend uk-text-default uk-text-bold">{ title }</legend>
-            {@render children()}
-        </fieldset>
+      {@render children()}
      {/if}
 
     { /* @ts-ignore */ null }


### PR DESCRIPTION
The `CreateUpdateItemForm` children input fields must be rendered by its underlying component depending on the form type. Also, `title` props were moved to the `_CardForm` and `_LoginForm`.