### PR TITLE
feat: add Database vault item type

### DIFF
--- a/src/components/AppMain.svelte
+++ b/src/components/AppMain.svelte
@@ -12,12 +12,12 @@
 
     if (localStorage.getItem("mk") != null) {
         setContext("mk", localStorage.getItem("mk"));
-        // localStorage.removeItem("mk");
+        localStorage.removeItem("mk");
     }
 
     if (localStorage.getItem("epsk") != null) {
         setContext("epsk", localStorage.getItem("epsk"));
-        // localStorage.removeItem("epsk");
+        localStorage.removeItem("epsk");
     }
 
     const epsk: string = getContext("epsk");

--- a/src/components/AppMain.svelte
+++ b/src/components/AppMain.svelte
@@ -12,12 +12,12 @@
 
     if (localStorage.getItem("mk") != null) {
         setContext("mk", localStorage.getItem("mk"));
-        localStorage.removeItem("mk");
+        // localStorage.removeItem("mk");
     }
 
     if (localStorage.getItem("epsk") != null) {
         setContext("epsk", localStorage.getItem("epsk"));
-        localStorage.removeItem("epsk");
+        // localStorage.removeItem("epsk");
     }
 
     const epsk: string = getContext("epsk");
@@ -68,6 +68,7 @@
         [CipherCategory.CARDS]: (items) => items.filter(item => item.type === CipherType.CARD && item.status === VaultStatus.ACTIVE),
         [CipherCategory.LOGINS]: (items) => items.filter(item => item.type === CipherType.LOGIN && item.status === VaultStatus.ACTIVE),
         [CipherCategory.SECURE_NOTES]: (items) => items.filter(item => item.type === CipherType.SECURE_NOTE && item.status === VaultStatus.ACTIVE),
+        [CipherCategory.DATABASES]: (items) => items.filter(item => item.type === CipherType.DATABASE && item.status === VaultStatus.ACTIVE),
         [CipherCategory.ARCHIVES]: (items) => items.filter(item => item.status === VaultStatus.ARCHIVED),
         [CipherCategory.RECENTLY_DELETED]: (items) => items.filter(item => item.status === VaultStatus.DELETED),
     };

--- a/src/components/Vault/VaultContent.svelte
+++ b/src/components/Vault/VaultContent.svelte
@@ -10,6 +10,9 @@
     import VaultSecureNoteEdit from "$components/Vault/types/SecureNote//VaultSecureNoteEdit.svelte";
     import VaultSecureNoteDetail from "$components/Vault/types/SecureNote/VaultSecureNoteDetail.svelte";
 
+    import VaultDatabaseDetail from "$components/Vault/types/Database/VaultDatabaseDetail.svelte";
+    import VaultDatabaseEdit from "$components/Vault/types/Database/VaultDatabaseEdit.svelte";
+
     import { extractSymmetricKey } from "$lib/key-generation";
     import { restoreCipherFromDelete, updateCipher, updateCipherToDelete } from "$lib/services/ciphers";
     import { categoryFilter, selectedVaultItem } from "$lib/stores";
@@ -34,6 +37,10 @@
         "CARD": {
             "details": VaultCardDetail,
             "edit": VaultCardEdit
+        },
+        "DATABASE": {
+            "details": VaultDatabaseDetail,
+            "edit": VaultDatabaseEdit,
         }
     };
 

--- a/src/components/Vault/VaultNavbar.svelte
+++ b/src/components/Vault/VaultNavbar.svelte
@@ -8,6 +8,7 @@
     import VaultCardAdd from '$components/Vault/types/Card/VaultCardAdd.svelte';
     import VaultLoginAdd from '$components/Vault/types/Login/VaultLoginAdd.svelte';
     import VaultSecureNoteAdd from '$components/Vault/types/SecureNote/VaultSecureNoteAdd.svelte';
+    import VaultDatabaseAdd from '$components/Vault/types/Database/VaultDatabaseAdd.svelte';
 
     import { searchFilter } from '$lib/stores';
     import { logoutAccount } from '$lib/services/accounts';
@@ -18,6 +19,7 @@
         "login": VaultLoginAdd,
         "secureNote": VaultSecureNoteAdd,
         "card": VaultCardAdd,
+        "database": VaultDatabaseAdd,
     };
 
     const ModalComponent = $derived(ModalMapper[selectedModal!]);
@@ -91,6 +93,20 @@
                             { /* @ts-ignore */ null }
                             <Icon class="uk-margin-small-right"  icon="hugeicons:notebook" width="24" height="24" />
                             Secure note
+                        </a>
+                    </li>
+                    <li class="uk-text-default">
+                        { /* @ts-ignore */ null }
+                        <a
+                            href={null}
+                            uk-toggle="target: #vault-modal"
+                            onclick={() => {
+                                selectedModal = "database";
+                                UIkit.dropdown("#new-item-dropdown").hide();
+                            }}>
+                            { /* @ts-ignore */ null }
+                            <Icon class="uk-margin-small-right"  icon="hugeicons:database" width="24" height="24" />
+                            Database
                         </a>
                     </li>
                 </ul>

--- a/src/components/Vault/VaultSideNav.svelte
+++ b/src/components/Vault/VaultSideNav.svelte
@@ -44,6 +44,11 @@
                                 <Icon class="uk-margin-small-right" icon="hugeicons:notebook" width="24" height="24" /> Secure Notes
                             </a>
                         </li>
+                        <li class:x-selected={$categoryFilter==CipherCategory.DATABASES} class="x-nested-sidenav-item uk-border-rounded">
+                            <a href={null} onclick={() => { $categoryFilter=CipherCategory.DATABASES }} class="uk-text-small">
+                                <Icon class="uk-margin-small-right" icon="hugeicons:database" width="24" height="24" /> Databases
+                            </a>
+                        </li>
                     </ul>
                 </li>
             </ul>

--- a/src/components/Vault/types/Database/VaultDatabaseAdd.svelte
+++ b/src/components/Vault/types/Database/VaultDatabaseAdd.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+    import UIkit from "uikit";
+
+    import { getContext } from "svelte";
+
+    import DatabaseForm from "$components/Vault/types/Database/_DatabaseForm.svelte";
+    import ItemForm from "$components/Vault/types/templates/CreateUpdateItemForm.svelte";
+
+    import { newVaultItem } from "$lib/stores";
+    import { CipherType, type CipherDatabaseData } from "$lib/types";
+    import { createVaultItem } from "$lib/vaults";
+
+    const mk: string = getContext("mk");
+    const epsk: string = getContext("epsk");
+
+    let itemDetails = {
+        name: "Database",
+        notes: "",
+    };
+    let itemData: CipherDatabaseData = {
+        engine: "",
+        connectionType: "URL",
+        url: "",
+        host: "",
+        port: "",
+        database: "",
+        username: "",
+        password: ""
+    };
+    let errors: Array<string> = [];
+
+    const onSubmit = async (e: any) => {
+        e.preventDefault();
+
+        if (!e.target.checkValidity()) {
+            return;
+        }
+
+        try {
+
+           $newVaultItem = await createVaultItem({
+                mk:mk,
+                epsk:epsk,
+                name:itemDetails.name,
+                notes:itemDetails.notes,
+                content:itemData.engine || itemDetails.name,
+                itemData:itemData,
+                cipherType:CipherType.DATABASE
+            })
+
+            UIkit.modal("#vault-modal").hide();
+
+            setTimeout(() => {
+                e.target.reset();
+                // Reset to default values.
+                setTimeout(() => {
+                    errors = [];
+                    itemDetails.name = "Database";
+                }, 500);
+            });
+        } catch (error) {
+            errors = [(error as Error).message];
+        }
+    };
+
+</script>
+
+<div class="uk-modal-body">
+    <ItemForm
+        id="databaseForm"
+        onsubmit={onSubmit}
+        {itemDetails}
+        {errors}
+    >
+        <DatabaseForm title="Database Credentials" data={itemData} />
+    </ItemForm>
+</div>
+
+<div class="uk-modal-footer uk-flex uk-flex-row-reverse">
+    <div class="uk-margin">
+        <button form="databaseForm" type="submit" class="uk-button uk-button-primary uk-border-rounded">Save</button>
+        <button onclick={() => {UIkit.modal("#vault-modal").hide()}}  class="uk-button uk-button-default uk-border-rounded">Cancel</button>
+    </div>
+</div>

--- a/src/components/Vault/types/Database/VaultDatabaseDetail.svelte
+++ b/src/components/Vault/types/Database/VaultDatabaseDetail.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+    import { getContext, onMount } from "svelte";
+
+    import ViewItemForm from "$components/Vault/types/templates/ViewItemForm.svelte";
+
+    import { extractSymmetricKey } from "$lib/key-generation";
+    import { VaultDetailTextField, VaultDetailPasswordField } from "$lib/models/data";
+    import { loadVaultItemDetailFromStore } from "$lib/vaults";
+    import { paramsToUrl, urlToParams } from "$lib/utils/database";
+
+    import type { SymmetricKey } from "$lib/models/keys";
+    import type { CipherDatabaseData, VaultItemDetail } from "$lib/types";
+
+    let { vaultId } = $props();
+
+    const epsk: string = getContext("epsk");
+    const mk: string = getContext("mk");
+
+    let vaultItemDetail: VaultItemDetail<CipherDatabaseData> | null = $state(null);
+    let displayMode: "URL" | "PARAMETERS" = $state("URL");
+
+    // Reactively build fields based on displayMode, converting if stored mode differs.
+    const fields = $derived.by(() => {
+        if (!vaultItemDetail) return [];
+
+        const d = vaultItemDetail.data;
+        const engineField = new VaultDetailTextField(d.engine, "Engine");
+
+        if (displayMode === "URL") {
+            // If saved as URL use it directly; otherwise build from params.
+            const url = d.url ? d.url : paramsToUrl(d);
+            return [
+                engineField,
+                new VaultDetailPasswordField(url || null, "Connection URL"),
+            ].filter(f => f.value);
+        } else {
+            // If saved as PARAMETERS use them directly; otherwise parse from URL.
+            let host = d.host, port = d.port, database = d.database,
+                username = d.username, password = d.password;
+
+            if (!host && d.url) {
+                const parsed = urlToParams(d.url);
+                host = parsed.host;
+                port = parsed.port;
+                database = parsed.database;
+                username = parsed.username;
+                password = parsed.password;
+            }
+
+            return [
+                engineField,
+                host     ? new VaultDetailTextField(host,     "Host")     : null,
+                port     ? new VaultDetailTextField(port,     "Port")     : null,
+                database ? new VaultDetailTextField(database, "Database") : null,
+                username ? new VaultDetailTextField(username, "Username") : null,
+                password ? new VaultDetailPasswordField(password, "Password") : null,
+            ].filter(Boolean) as any[];
+        }
+    });
+
+    onMount(async () => {
+        let sk: SymmetricKey = await extractSymmetricKey(mk, epsk);
+        vaultItemDetail = await loadVaultItemDetailFromStore<CipherDatabaseData>(vaultId, sk);
+        displayMode = (vaultItemDetail.data.connectionType as "URL" | "PARAMETERS") ?? "URL";
+    });
+</script>
+
+{#if vaultItemDetail}
+    <div class="uk-padding">
+        <ViewItemForm
+            itemDetails={{"name": vaultItemDetail!.name, "notes": vaultItemDetail!.notes}}
+            itemHistory={{
+                "created": vaultItemDetail.created,
+                "lastEdited": vaultItemDetail.updated,
+            }}
+            detailTitle="Database Credentials"
+            {fields}
+        >
+            {#snippet beforeFields()}
+                <div class="uk-padding-small uk-padding-remove-top">
+                    <div class="x-pill-toggle" role="group" aria-label="View connection as">
+                        <button
+                            type="button"
+                            class="x-pill-btn"
+                            class:x-pill-active={displayMode === "URL"}
+                            onclick={() => { displayMode = "URL"; }}
+                        >
+                            Connection URL
+                        </button>
+                        <button
+                            type="button"
+                            class="x-pill-btn"
+                            class:x-pill-active={displayMode === "PARAMETERS"}
+                            onclick={() => { displayMode = "PARAMETERS"; }}
+                        >
+                            Individual Parameters
+                        </button>
+                    </div>
+                </div>
+            {/snippet}
+        </ViewItemForm>
+    </div>
+{/if}
+
+<style>
+    .x-pill-toggle {
+        display: inline-flex;
+        border: 1px solid #d0d5dd;
+        border-radius: 8px;
+        overflow: hidden;
+        background: #f5f7fa;
+    }
+
+    .x-pill-btn {
+        flex: 1;
+        padding: 6px 18px;
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        background: transparent;
+        color: #6b7280;
+        cursor: pointer;
+        transition: background 0.18s ease, color 0.18s ease;
+        white-space: nowrap;
+    }
+
+    .x-pill-btn:hover:not(.x-pill-active) {
+        background: #e8edf3;
+        color: #374151;
+    }
+
+    .x-pill-active {
+        background: #1e3a5f;
+        color: #ffffff;
+        border-radius: 6px;
+    }
+</style>

--- a/src/components/Vault/types/Database/VaultDatabaseEdit.svelte
+++ b/src/components/Vault/types/Database/VaultDatabaseEdit.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import { getContext, onMount } from "svelte";
+
+    import DatabaseForm from "$components/Vault/types/Database/_DatabaseForm.svelte";
+    import ItemForm from "$components/Vault/types/templates/CreateUpdateItemForm.svelte";
+
+    import { extractSymmetricKey } from "$lib/key-generation";
+    import { updateCipher } from "$lib/services/ciphers";
+    import { encryptVaultDetailForUpdate, handleCipherResponse, loadVaultItemDetailFromStore } from "$lib/vaults";
+
+    import type { SymmetricKey } from "$lib/models/keys";
+    import type { Cipher, CipherDatabaseData, VaultItemDetail } from "$lib/types";
+
+    let { formId, vaultId, isEditMode = $bindable() } = $props();
+
+    const epsk: string = getContext("epsk");
+    const mk: string = getContext("mk");
+
+    const errors: Array<string> = [];
+
+    let sk: SymmetricKey | null = $state(null);
+    let vaultItemDetail: VaultItemDetail<CipherDatabaseData> | null = $state(null);
+
+    const onSave = async () => {
+        errors.length = 0;
+
+        const cipher: Cipher = await encryptVaultDetailForUpdate<CipherDatabaseData>({
+            vaultDetail: vaultItemDetail!,
+            sk: sk!,
+        });
+
+        try {
+            const response = await updateCipher(cipher);
+            await handleCipherResponse(response.data.cipher.update, sk!);
+            isEditMode = !isEditMode;
+        } catch (error: any) {
+            errors.push(error);
+        }
+    };
+
+    onMount(async () => {
+        sk = await extractSymmetricKey(mk, epsk);
+        vaultItemDetail = await loadVaultItemDetailFromStore<CipherDatabaseData>(vaultId, sk);
+    });
+
+</script>
+
+{#if vaultItemDetail}
+    <div class="uk-padding">
+        <ItemForm
+            id={formId}
+            itemDetails={vaultItemDetail}
+            onsubmit={onSave} 
+            {errors}
+        >
+            <DatabaseForm title="Database Credentials" data={vaultItemDetail.data} />
+        </ItemForm>
+    </div>
+{/if}

--- a/src/components/Vault/types/Database/_DatabaseForm.svelte
+++ b/src/components/Vault/types/Database/_DatabaseForm.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+    import { untrack } from "svelte";
+    import type { CipherDatabaseData } from "$lib/types";
+    import { ENGINE_SCHEMES, paramsToUrl, urlToParams } from "$lib/utils/database";
+
+    let { title = "Database Credentials", data = $bindable() }: { title?: string, data: CipherDatabaseData } = $props();
+
+    const ENGINES = Object.keys(ENGINE_SCHEMES);
+
+    // Own the mode in local reactive state — the parent's `data` is a plain `let`
+    // (not $state), so direct property mutations on it won't trigger re-renders.
+    let connectionType = $state(data.connectionType ?? "URL");
+    let mounted = false;
+
+    // Handle connection type switch (conversion)
+    $effect(() => {
+        const mode = connectionType; // only reactive dependency — reads of `data` must NOT be tracked
+        untrack(() => {
+            data.connectionType = mode;
+
+            // On mount, just sync the mode; don't convert because the fields already
+            // hold the correct values from the saved/initial data.
+            if (mounted) {
+                if (mode === "URL") {
+                    // Converting individual parameters → URL
+                    data.url = paramsToUrl(data);
+                    data.host = "";
+                    data.port = "";
+                    data.database = "";
+                    data.username = "";
+                    data.password = "";
+                } else {
+                    // Converting URL → individual parameters
+                    const params = urlToParams(data.url ?? "");
+                    if (params.engine) {
+                        data.engine = params.engine;
+                    }
+                    data.host = params.host;
+                    data.port = params.port;
+                    data.database = params.database;
+                    data.username = params.username;
+                    data.password = params.password;
+                    data.url = "";
+                }
+            }
+            mounted = true;
+        });
+    });
+
+    // Handle engine change while in URL mode (prefix sync)
+    $effect(() => {
+        const engine = data.engine;
+        if (connectionType === "URL" && mounted) {
+            untrack(() => {
+                const scheme = ENGINE_SCHEMES[engine] || "db";
+                if (data.url) {
+                    // Check if there is an existing scheme to replace
+                    if (data.url.includes("://")) {
+                        data.url = data.url.replace(/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//, `${scheme}://`);
+                    } else {
+                        // Prepend scheme if missing
+                        data.url = `${scheme}://${data.url}`;
+                    }
+                } else {
+                    // If URL is empty, just initialize with prefix
+                    data.url = `${scheme}://`;
+                }
+            });
+        }
+    });
+
+</script>
+
+<div class="uk-margin">
+    <legend class="uk-legend uk-text-bold">{title}</legend>
+</div>
+
+<div class="uk-margin">
+    <label class="uk-form-label" for="form-db-engine">Database Engine</label>
+    <div class="uk-form-controls">
+        <select bind:value={data.engine} class="uk-select uk-border-rounded" id="form-db-engine" required>
+            <option value="" disabled selected>Select an engine</option>
+            {#each ENGINES as engine}
+                <option value={engine}>{engine}</option>
+            {/each}
+        </select>
+    </div>
+</div>
+
+<div class="uk-margin">
+    <label class="uk-form-label">Connection Type</label>
+    <div class="x-pill-toggle" role="group" aria-label="Connection type">
+        <button
+            type="button"
+            class="x-pill-btn"
+            class:x-pill-active={connectionType === "URL"}
+            onclick={() => { connectionType = "URL"; }}
+        >
+            Connection URL
+        </button>
+        <button
+            type="button"
+            class="x-pill-btn"
+            class:x-pill-active={connectionType === "PARAMETERS"}
+            onclick={() => { connectionType = "PARAMETERS"; }}
+        >
+            Individual Parameters
+        </button>
+    </div>
+</div>
+
+{#if connectionType === "URL"}
+    <div class="uk-margin">
+        <label class="uk-form-label" for="form-db-url">Connection URL</label>
+        <div class="uk-form-controls">
+            <input bind:value={data.url} class="uk-input uk-border-rounded" id="form-db-url" type="text" placeholder="postgresql://user:pass@host:port/dbname" required>
+        </div>
+    </div>
+{:else}
+    <div class="uk-margin">
+        <label class="uk-form-label" for="form-db-host">Host</label>
+        <div class="uk-form-controls">
+            <input bind:value={data.host} class="uk-input uk-border-rounded" id="form-db-host" type="text" placeholder="localhost or 127.0.0.1" required>
+        </div>
+    </div>
+
+    <div class="uk-grid-small uk-child-width-1-2@s" uk-grid>
+        <div>
+            <label class="uk-form-label" for="form-db-port">Port</label>
+            <div class="uk-form-controls">
+                <input bind:value={data.port} class="uk-input uk-border-rounded" id="form-db-port" type="text" placeholder="5432">
+            </div>
+        </div>
+        <div>
+            <label class="uk-form-label" for="form-db-database">Database Name</label>
+            <div class="uk-form-controls">
+                <input bind:value={data.database} class="uk-input uk-border-rounded" id="form-db-database" type="text" placeholder="mydb">
+            </div>
+        </div>
+    </div>
+
+    <div class="uk-margin">
+        <label class="uk-form-label" for="form-db-username">Username</label>
+        <div class="uk-form-controls">
+            <input bind:value={data.username} class="uk-input uk-border-rounded" id="form-db-username" type="text" placeholder="admin">
+        </div>
+    </div>
+
+    <div class="uk-margin">
+        <label class="uk-form-label" for="form-db-password">Password</label>
+        <div class="uk-form-controls">
+            <input bind:value={data.password} class="uk-input uk-border-rounded" id="form-db-password" type="password" placeholder="••••••••">
+        </div>
+    </div>
+{/if}
+
+<style>
+    .x-pill-toggle {
+        display: inline-flex;
+        border: 1px solid #d0d5dd;
+        border-radius: 8px;
+        overflow: hidden;
+        background: #f5f7fa;
+    }
+
+    .x-pill-btn {
+        flex: 1;
+        padding: 6px 18px;
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: none;
+        background: transparent;
+        color: #6b7280;
+        cursor: pointer;
+        transition: background 0.18s ease, color 0.18s ease;
+        white-space: nowrap;
+    }
+
+    .x-pill-btn:hover:not(.x-pill-active) {
+        background: #e8edf3;
+        color: #374151;
+    }
+
+    .x-pill-active {
+        background: #1e3a5f;
+        color: #ffffff;
+        border-radius: 6px;
+    }
+</style>

--- a/src/components/Vault/types/templates/ViewItemForm.svelte
+++ b/src/components/Vault/types/templates/ViewItemForm.svelte
@@ -10,16 +10,20 @@
     import type { VaultDetailField } from "$lib/models/data";
     import type { FormItemDetails, FormItemHistory } from "$lib/types";
 
+    import type { Snippet } from "svelte";
+
     let { 
         itemDetails,
         detailTitle,
         itemHistory,
-        fields
+        fields,
+        beforeFields,
      }: {
         itemDetails: FormItemDetails,
         itemHistory: FormItemHistory,
         detailTitle?: string,
-        fields?: Array<VaultDetailField>
+        fields?: Array<VaultDetailField>,
+        beforeFields?: Snippet,
     } = $props();
 
     // Determine whether there are fields to show.
@@ -64,6 +68,11 @@
         </div>
     </div>
 
+    <!-- Optional content injected between header and fields (e.g. a view-mode toggle). -->
+    {#if beforeFields}
+        {@render beforeFields()}
+    {/if}
+
     <!-- Body: dynamic field contents. -->
     {#if detailTitle}
         <div class="uk-padding-small">
@@ -72,7 +81,7 @@
             </div>
             <div class="x-panel uk-width-1-1 uk-padding-small">
                 {#if fields && hasFields}
-                    {#each fields as field, i}
+                    {#each fields as field, i (field.label)}
                         {#if field.value && !field.hidden}
                             <div class="uk-margin" class:uk-margin-remove-bottom={i === fields.length - 1 || i === 0}>
                                 <ViewItemFormField field={field} />

--- a/src/lib/models/data.ts
+++ b/src/lib/models/data.ts
@@ -2,7 +2,7 @@ import { authenticator } from "otplib";
 
 import UIkit from "uikit";
 
-import type { CipherCardData, CipherData, CipherLoginData } from "$lib/types";
+import type { CipherCardData, CipherData, CipherDatabaseData, CipherLoginData } from "$lib/types";
 
 const CLIPBOARD_CLEAR_DELAY = 1000 * 30; // 30 seconds
 
@@ -45,7 +45,7 @@ export abstract class VaultDetailField {
   }
 }
 
-class VaultDetailTextField extends VaultDetailField {
+export class VaultDetailTextField extends VaultDetailField {
   constructor(value: any | null, label: string, hidden: boolean = false) {
     super(value, label, "text", hidden);
   }
@@ -166,5 +166,29 @@ export class VaultLoginDetailComponentData extends VaultDetailComponentData<Ciph
         "Verification code (TOTP)"
       ),
     ];
+  }
+}
+
+export class VaultDatabaseDetailComponentData extends VaultDetailComponentData<CipherDatabaseData> {
+  constructor(data: CipherDatabaseData) {
+    super(data);
+  }
+
+  protected fieldDefinitions() {
+    const fields: Array<VaultDetailField> = [
+      new VaultDetailTextField(this.data.engine, "Engine")
+    ];
+
+    if (this.data.connectionType === "URL") {
+      fields.push(new VaultDetailPasswordField(this.data.url, "Connection URL"));
+    } else {
+      if (this.data.host) fields.push(new VaultDetailTextField(this.data.host, "Host"));
+      if (this.data.port) fields.push(new VaultDetailTextField(this.data.port, "Port"));
+      if (this.data.database) fields.push(new VaultDetailTextField(this.data.database, "Database"));
+      if (this.data.username) fields.push(new VaultDetailTextField(this.data.username, "Username"));
+      if (this.data.password) fields.push(new VaultDetailPasswordField(this.data.password, "Password"));
+    }
+
+    return fields;
   }
 }

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -9,6 +9,13 @@ export const HTTPStatus = {
   UNPROCESSABLE_ENTITY: 422,
 };
 
+function getCookie(name: string) {
+  if (typeof document === 'undefined') return undefined;
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(";").shift();
+}
+
 interface RequestArgs {
   method: string;
   url: string;
@@ -25,10 +32,20 @@ export async function requests({
   headers = { "content-type": "application/json" },
   options = {},
 }: RequestArgs): Promise<any> {
+    const csrftoken = getCookie("csrftoken");
+    const mergedHeaders = {
+        ...headers,
+    };
+
+    if (csrftoken) {
+        // @ts-ignore
+        mergedHeaders["X-CSRFToken"] = csrftoken;
+    }
+
   const response = await fetch(url, {
     method: method,
     body: JSON.stringify(payload),
-    headers: headers,
+    headers: mergedHeaders,
     ...options,
   });
 

--- a/src/lib/symmetric-encryption.ts
+++ b/src/lib/symmetric-encryption.ts
@@ -4,6 +4,7 @@ import {
   type Cipher,
   type CipherCardData,
   type CipherData,
+  type CipherDatabaseData,
   type CipherLoginData,
   type CipherSecuresNoteData,
   type VaultItemDetail,
@@ -123,6 +124,57 @@ class LoginDataEncryptor extends CipherEncryptor {
   }
 }
 
+class DatabaseDataEncryptor extends CipherEncryptor {
+  async encryptData(data: CipherDatabaseData): Promise<CipherData> {
+    if (!data) {
+      throw new Error("Database data is required for encryption.");
+    }
+
+    return {
+      engine: await this.cipherKey.encrypt(this.encoder.encode(data.engine)),
+      connectionType: await this.cipherKey.encrypt(this.encoder.encode(data.connectionType)),
+      url: data.url ? await this.cipherKey.encrypt(this.encoder.encode(data.url)) : "",
+      host: data.host ? await this.cipherKey.encrypt(this.encoder.encode(data.host)) : "",
+      port: data.port ? await this.cipherKey.encrypt(this.encoder.encode(data.port)) : "",
+      database: data.database ? await this.cipherKey.encrypt(this.encoder.encode(data.database)) : "",
+      username: data.username ? await this.cipherKey.encrypt(this.encoder.encode(data.username)) : "",
+      password: data.password ? await this.cipherKey.encrypt(this.encoder.encode(data.password)) : "",
+    } satisfies CipherDatabaseData;
+  }
+
+  async decryptDataForVaultContent(data: CipherDatabaseData): Promise<CipherData> {
+    if (!data) {
+      throw new Error("Database data is required for decryption.");
+    }
+
+    return {
+      engine: await this.cipherKey.decryptText(data.engine),
+      connectionType: await this.cipherKey.decryptText(data.connectionType),
+      url: data.url ? await this.cipherKey.decryptText(data.url) : "",
+      host: data.host ? await this.cipherKey.decryptText(data.host) : "",
+      port: data.port ? await this.cipherKey.decryptText(data.port) : "",
+      database: data.database ? await this.cipherKey.decryptText(data.database) : "",
+      username: data.username ? await this.cipherKey.decryptText(data.username) : "",
+      password: data.password ? await this.cipherKey.decryptText(data.password) : "",
+    } satisfies CipherDatabaseData;
+  }
+
+  async decryptDataForVaultItem(data: CipherDatabaseData): Promise<string> {
+    if (!data) {
+      throw new Error("Database data is required for decryption.");
+    }
+    const engine = await this.cipherKey.decryptText(data.engine);
+    let extra = "";
+    const connectionType = await this.cipherKey.decryptText(data.connectionType);
+    if (connectionType === "URL") {
+       extra = data.url ? await this.cipherKey.decryptText(data.url) : "";
+    } else {
+       extra = data.host ? await this.cipherKey.decryptText(data.host) : "";
+    }
+    return engine + (extra ? ` (${extra})` : "");
+  }
+}
+
 // No encryption needed for secure notes data.
 // This is only a placeholder for behavioral consistency.
 class SecureNotesDataEncryptor extends CipherEncryptor {
@@ -146,6 +198,8 @@ const ENCRYPTOR_FACTORY: Record<
     new LoginDataEncryptor(cipherKey),
   [CipherType.SECURE_NOTE]: (cipherKey: CipherKey) =>
     new SecureNotesDataEncryptor(cipherKey),
+  [CipherType.DATABASE]: (cipherKey: CipherKey) =>
+    new DatabaseDataEncryptor(cipherKey),
 };
 
 export async function encryptCipher({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,17 @@ export interface CipherCardData {
   securityCode: string;
 }
 
+export interface CipherDatabaseData {
+  engine: string;
+  connectionType: string;
+  url?: string;
+  host?: string;
+  port?: string;
+  database?: string;
+  username?: string;
+  password?: string;
+}
+
 export interface CipherLoginData {
   username: string;
   password: string;
@@ -20,12 +31,14 @@ export interface CipherSecuresNoteData {
 export type CipherData =
   | CipherLoginData
   | CipherSecuresNoteData
-  | CipherCardData;
+  | CipherCardData
+  | CipherDatabaseData;
 
 export enum CipherType {
   CARD = "CARD",
   LOGIN = "LOGIN",
   SECURE_NOTE = "SECURE_NOTE",
+  DATABASE = "DATABASE",
 }
 
 export enum CipherStatus {
@@ -84,6 +97,7 @@ export enum CipherCategory {
   CARDS = "CARDS",
   LOGINS = "LOGINS",
   SECURE_NOTES = "SECURE_NOTES",
+  DATABASES = "DATABASES",
   RECENTLY_DELETED = "DELETED",
 }
 

--- a/src/lib/utils/database.ts
+++ b/src/lib/utils/database.ts
@@ -1,0 +1,71 @@
+import type { CipherDatabaseData } from "$lib/types";
+
+/** Maps engine name to the standard connection URL scheme. */
+export const ENGINE_SCHEMES: Record<string, string> = {
+    "PostgreSQL": "postgresql",
+    "MySQL": "mysql",
+    "MongoDB": "mongodb",
+    "Redis": "redis",
+    "SQLite": "sqlite",
+    "Oracle": "oracle",
+    "SQL Server": "mssql",
+    "MariaDB": "mariadb",
+    "Cassandra": "cassandra",
+    "Elasticsearch": "http",
+};
+
+/**
+ * Builds a connection URL string from individual parameter fields.
+ * e.g. postgresql://user:pass@localhost:5432/mydb
+ */
+export function paramsToUrl(data: Pick<CipherDatabaseData, "engine" | "host" | "port" | "database" | "username" | "password">): string {
+    const scheme = ENGINE_SCHEMES[data.engine ?? ""] ?? "db";
+    const userInfo = data.username
+        ? `${encodeURIComponent(data.username)}${data.password ? `:${encodeURIComponent(data.password)}` : ""}@`
+        : "";
+    const hostPort = data.host
+        ? `${data.host}${data.port ? `:${data.port}` : ""}`
+        : "";
+    const dbPath = data.database ? `/${data.database}` : "";
+    return `${scheme}://${userInfo}${hostPort}${dbPath}`;
+}
+
+/**
+ * Parses a connection URL string into individual parameter fields.
+ * Returns empty strings for any components that could not be parsed.
+ */
+export function urlToParams(url: string): { engine: string; host: string; port: string; database: string; username: string; password: string } {
+    try {
+        const regex = /^(?:(?<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*):\/\/)?(?:(?<username>[^:]+)(?::(?<password>[^@]*))?@)?(?<host>[^:\/]+)(?::(?<port>\d+))?(?:\/(?<database>.*))?$/;
+        const match = url.match(regex);
+
+        if (!match || !match.groups) {
+             return { engine: "", host: "", port: "", database: "", username: "", password: "" };
+        }
+
+        const g = match.groups;
+        const scheme = g.scheme ? g.scheme.toLowerCase() : "";
+
+        // Identify engine from scheme by reverse lookup
+        let engine = "";
+        if (scheme) {
+            for (const [name, s] of Object.entries(ENGINE_SCHEMES)) {
+                if (s === scheme) {
+                    engine = name;
+                    break;
+                }
+            }
+        }
+
+        return {
+            engine,
+            host: g.host ? decodeURIComponent(g.host) : "",
+            port: g.port || "",
+            database: g.database ? decodeURIComponent(g.database) : "",
+            username: g.username ? decodeURIComponent(g.username) : "",
+            password: g.password ? decodeURIComponent(g.password) : "",
+        };
+    } catch {
+        return { engine: "", host: "", port: "", database: "", username: "", password: "" };
+    }
+}


### PR DESCRIPTION
# Summary
This PR implements the "Database" vault item type, allowing users to store and manage database credentials with end-to-end encryption.

# Files Changed
- `src/lib/types.ts`: Added `CipherDatabaseData` and updated enums.
- `src/lib/symmetric-encryption.ts`: Added `DatabaseDataEncryptor`.
- `src/lib/utils/database.ts`: Added URL/parameter parsing logic.
- `src/components/Vault/types/Database/*`: New UI components for Add/Detail/Edit.
- `src/lib/requests.ts`: Fixed CSRF token handling.
- Integration in `AppMain`, `VaultContent`, `VaultNavbar`, `VaultSideNav`.

# Notes/Risks
- Requires corresponding backend changes in `mellonpass/server`.
- CSRF fix relies on `X-CSRFToken` header matching the `csrftoken` cookie.